### PR TITLE
[RSpec]User・PostモデルのバリデーションにSpecを追加

### DIFF
--- a/spec/jobs/hello_world_job_spec.rb
+++ b/spec/jobs/hello_world_job_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe HelloWorldJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -21,4 +21,46 @@ RSpec.describe Post, type: :model do
       expect(post).to_not be_valid
     end
   end
+
+  # ストーリーのバリデーション
+  context 'ストーリーが空の場合' do
+    post = Post.new(story: nil)
+    post.valid?
+    
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Storyを入力してください')
+      expect(post).to_not be_valid
+    end
+  end
+
+  context 'ストーリーが300文字を超える場合' do
+    post = Post.new(story: 'ごめん' * 100 + 'え')
+    post.valid?
+
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Storyは300文字以内で入力してください')
+      expect(post).to_not be_valid
+    end
+  end
+
+  # オーダーのバリデーション
+  context 'オーダーが空の場合' do
+    post = Post.new(order: nil)
+    post.valid?
+    
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Orderを入力してください')
+      expect(post).to_not be_valid
+    end
+  end
+
+  context 'オーダーが300文字を超える場合' do
+    post = Post.new(order: 'ごめん' * 100 + 'え')
+    post.valid?
+
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Orderは300文字以内で入力してください')
+      expect(post).to_not be_valid
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  # タイトルのバリデーション
+  context 'タイトルが空の場合' do
+    post = Post.new(title: nil)
+    post.valid?
+    
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Titleを入力してください')
+      expect(post).to_not be_valid
+    end
+  end
+
+  context 'タイトルが32文字を超える場合' do
+    post = Post.new(title: '僕が恋をしたのは彼女ではなく彼女の持つ才能とそれに嫉妬する僕の感情')
+    post.valid?
+
+    it '無効になる' do
+      expect(post.errors.full_messages).to include('Titleは32文字以内で入力してください')
+      expect(post).to_not be_valid
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -63,4 +63,22 @@ RSpec.describe Post, type: :model do
       expect(post).to_not be_valid
     end
   end
+
+  # scopeの取得
+  context 'new_arrivを使用した場合' do
+    test_posts = 10.times do |n|
+      Post.create!(
+        title: 'タイトル',
+        story: 'ストーリー説明',
+        order: '素敵なストーリーにしてください。',
+        user_id: 1
+        )
+    end
+
+    posts = Post.new_arriv
+
+    it '10件取得する' do
+      expect(posts.count).to eq 10
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,24 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  context '正しい形式で入力した場合' do
-    user = User.new(
-        name: "name1",
-        email: "aaaa1@gmail.com",
-        password: "password",
-    )
-
-    it 'サインアップできる' do
-      expect(user).to be_valid
-    end
-  end
-
+  # ユーザー名のバリデーション
   context 'ユーザー名を空でサインアップした場合' do
     user = User.new(name: nil)
     user.valid?
 
     it '無効になる' do
-      expect(user.errors.full_messages).to include("ユーザー名を入力してください")
+      expect(user.errors.full_messages).to include('ユーザー名を入力してください')
       expect(user).to_not be_valid
     end
   end
@@ -28,7 +17,38 @@ RSpec.describe User, type: :model do
     user.valid?
 
     it '無効になる' do
-      expect(user.errors.full_messages).to include("ユーザー名は25文字以内で入力してください")
+      expect(user.errors.full_messages).to include('ユーザー名は25文字以内で入力してください')
+      expect(user).to_not be_valid
+    end
+  end
+
+  # メールアドレスのバリデーション
+  context 'メールアドレスを空でサインアップした場合' do
+    user = User.new(email: nil)
+    user.valid?
+
+    it '無効になる' do
+      expect(user.errors.full_messages).to include('メールアドレスを入力してください')
+      expect(user).to_not be_valid
+    end
+  end
+
+  context '既に存在するメールアドレスを入力した場合' do
+    user = User.create(
+      name: 'name1',
+      email: 'aaaa2@gmail.com',
+      password: 'password',
+    )
+
+    user = User.new(
+      name: 'name2',
+      email: 'aaaa2@gmail.com',
+      password: 'password',
+    )
+    user.valid?
+
+    it '無効になる' do
+      expect(user.errors.full_messages).to include('メールアドレスはすでに存在します')
       expect(user).to_not be_valid
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,24 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
   end
+
+  context 'ユーザー名を空でサインアップした場合' do
+    user = User.new(name: nil)
+    user.valid?
+
+    it '無効になる' do
+      expect(user.errors.full_messages).to include("ユーザー名を入力してください")
+      expect(user).to_not be_valid
+    end
+  end
+
+  context 'ユーザー名が25文字を超える場合' do
+    user = User.new(name: 'a' * 26)
+    user.valid?
+
+    it '無効になる' do
+      expect(user.errors.full_messages).to include("ユーザー名は25文字以内で入力してください")
+      expect(user).to_not be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context '正しい形式で入力した場合' do
+    user = User.new(
+        name: "name1",
+        email: "aaaa1@gmail.com",
+        password: "password",
+    )
+
+    it 'サインアップできる' do
+      expect(user).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## テストした項目

### Userモデル
- name（空、文字数25文字以内）
- email（空、一意性）

### Postモデル
- title（空、文字数32文字以内）
- story（空、文字数300文字以内）
- order（空、文字数300文字以内）
- new_arriv（scopeが正しいか {しかし、これ自体が不完全である} ）