### PR TITLE
[#176589056]ルートシフト作戦

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Home controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,12 @@
+class HomeController < ApplicationController
+  skip_before_action :authenticate_user!, only: :top
+
+  def top
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).order(id: "DESC")
+    # top-raiking
+    @ranking_posts = Post.rank
+    #top-new-arrival
+    @new_arrival_posts = Post.new_arriv
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,0 +1,55 @@
+= provide(:title, "")
+
+section.bg-top
+  .top-container
+    .top-header
+      // headerロゴ
+      .top-header-logo
+        h1 = link_to "RELIER", root_path
+      // headerリスト
+      .top-header-list
+        ul
+          - if user_signed_in?
+            li = link_to "マイページ", user_path(current_user)
+            li = link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: 'ログアウトしますか?' }
+          - else
+            li = link_to "サインイン", new_user_session_path
+    // 検索窓
+    .search
+      = search_form_for @q do |f|
+        = f.search_field :title_cont, placeholder: "タイトル名、ジャンルで検索"
+        = f.submit "検索"
+
+section.top-container
+  - unless user_signed_in?
+    // LP遷移ボタン
+    .top-newuser-action
+      p = link_to "はじめてご利用の方へ", lp_path
+  // おすすめ作品
+  .top-ranking-wrapper
+    .top-ranking-title
+      h2 おすすめ作品
+    .top-ranking.over-flow
+      - @ranking_posts.each do |post|
+        .ranking-content
+          .top-post-img
+            = link_to image_tag("no_image_book.jpg"), post
+          h3.top-post-title = post.title.truncate(27)
+          / p.top-post-story = post.story
+          p.top-post-link = link_to "詳細をみる", post
+  // 新着作品
+  .top-new-arrival-wrapper
+    .top-new-arrival-title
+      h2 新着作品
+    .top-new-arrival.over-flow
+      - @new_arrival_posts.each do |post|
+        .new-arrival-content
+          .top-post-img
+            = link_to post do
+              - if post.image.present?
+                = image_tag(post.image.url)
+              - else
+                = image_tag("no_image_book.jpg")
+          h3.top-post-title = post.title.truncate(27)
+          / p.top-post-story = post.story
+          p.top-post-link = link_to "詳細をみる", post

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,24 +1,4 @@
-= provide(:title, "")
-
-section.bg-top
-  .top-container
-    .top-header
-      // headerロゴ
-      .top-header-logo
-        h1 = link_to "RELIER", root_path
-      // headerリスト
-      .top-header-list
-        ul
-          - if user_signed_in?
-            li = link_to "マイページ", user_path(current_user)
-            li = link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: 'ログアウトしますか?' }
-          - else
-            li = link_to "サインイン", new_user_session_path
-    // 検索窓
-    .search
-      = search_form_for @q do |f|
-        = f.search_field :title_cont, placeholder: "タイトル名、ジャンルで検索"
-        = f.submit "検索"
+= provide(:title, "検索結果")
 
 section.top-container
   - unless user_signed_in?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users
   root 'home#top'
+  devise_for :users
 
   resources :posts do
     resources :microposts, only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'posts#index'
+  root 'home#top'
 
   resources :posts do
     resources :microposts, only: [:create, :destroy]

--- a/spec/requests/home_request_spec.rb
+++ b/spec/requests/home_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+
+end


### PR DESCRIPTION
## 詳細
- root_pathのコントローラーをずらす

従来の仕組みでは、`posts#index`をroot_pathに設定していたが、今後、検索機能を実装することがあった際に、`posts#index`は使いたいので、新たに`home#top`を作成。

これをroot_pathに設定した。


## 追加・削除したもの

- `HomeController`
- `home#top`のアクション
- `posts#index`の上部ヘッダーみたいな部分
