### PR TITLE
[#177519935]未ログインユーザーコメント繋ぐ 他1件...

### DIFF
--- a/app/controllers/free_comments_controller.rb
+++ b/app/controllers/free_comments_controller.rb
@@ -1,9 +1,10 @@
 
-class CommentsController < ApplicationController
+class FreeCommentsController < ApplicationController
+  skip_before_action :authenticate_user!
 
   def create
     if user_signed_in?
-      @free_comment = FreeComment.new(content: params[:content])
+      @free_comment = FreeComment.new(content: params[:free_comment][:content])
       @free_comment.username = current_user.name
     else
       @free_comment = FreeComment.new(free_comment_params)
@@ -17,7 +18,7 @@ class CommentsController < ApplicationController
       redirect_to @post
     else
       flash[:alert] = 'コメント作成に失敗しました'
-      render 'posts/show'
+      redirect_to @post
     end
   end
 

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -4,7 +4,6 @@ class MicropostsController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    @microposts = @post.microposts
     @micropost = Micropost.new(micropost_params)
     @micropost.user_id = current_user.id
     @micropost.post_id = @post.id

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,7 @@ class PostsController < ApplicationController
 
     @free_comments = @post.free_comments.order(id: "DESC")
     @free_comment = FreeComment.new
+    @default_name = '名無しのリライアーさん'
   end
 
   def new

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -671,4 +671,22 @@ css:
     .post-sub-user-name p {
       font-size: 0.95rem;
     }
+
+    .free-post-log {
+      width: 280px;
+    }
+
+    .free-post-contents {
+      margin-top: 6%;
+      margin-bottom: 9%;
+    }
+
+    .post-show-free-post-form .free-form input[type="text"] {
+      width: 244px;
+      margin-bottom: 2%;
+    }
+
+    .post-show-free-post-form {
+      margin-bottom: 18%;
+    }
   }

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -72,7 +72,7 @@
             - if user_signed_in?
               p 文章を作成
               = form_for [@post, @micropost] do |f|
-                = f.text_field :content, :placeholder => "55文字以内で文章を作成"
+                = f.text_field :content, placeholder: "55文字以内で文章を作成"
                 = f.submit '作成', data: { confirm: "投稿しますか？"}
             - else
               p.not-signin 小説作成に参加するには、#{link_to "サインイン", new_user_session_path}してください
@@ -103,21 +103,20 @@
         .free-post-title
           h3 フリーコメント
         .free-posts-wrapper
-          .free-post-contents
-            // TODO: 本来の姿
-            / - @free_comments.each do |fc|
-            .free-post-content
-              .free-post-image
-                p.image = image_tag  "no_image.png"
-                / p.image = image_tag  "no_image.png"
-              .free-post-name
-                p.name 名無しのリライアーさん
-                / p.name = fc.username
-            .free-post-msg
-              p.post-content お前の作品好きだわ、なんていうかさ、良いんだよね〜なんでだろう、、
-              / p.post-content = fc.content
-              p.time 5分前
-              / = "#{time_ago_in_words(fc.created_at)}前"
+          - if @free_comments.present?
+            - @free_comments.each do |fc|
+              .free-post-contents
+                .free-post-content
+                  .free-post-image
+                    p.image = image_tag  "no_image.png"
+                  .free-post-name
+                    p.name = fc.username
+                .free-post-msg
+                  p.post-content = fc.content
+                  p.time = "#{time_ago_in_words(fc.created_at)}前"
+          - else
+            p.not-free-post このスペースは誰でも自由に書き込むことが出来ます
+
 
     // フリーコメントの作成フォーム
     .post-show-free-post-form
@@ -125,17 +124,11 @@
         h3 フリーコメントを作成
       .free-form
         form
-          / - unless user_signed_in?
-          input type="text" name="username" size="37" value="名無しのリライアーさん" placeholder="25文字以内でHNを設定(空白禁止)"
-          br
-          input type="text" name="content" size="44" placeholder="55文字以内で文章を作成"
-          input type="submit" value="作成"
-        // TODO: 本来の姿
-        / = form_for [@post, @free_comment] do |f|
-          / - unless user_signed_in?
-            / = f.text_field :username, value: @default_name
-          / = f.text_field :content, :placeholder => "55文字以内で文章を作成"
-          / = f.submit '作成', data: { confirm: "投稿しますか？"}
+        = form_for [@post, @free_comment] do |f|
+          - unless user_signed_in?
+            = f.text_field :username, value: @default_name, placeholder: "25文字以内でHNを設定（空白禁止）", size: 32
+          = f.text_field :content, placeholder: "55文字以内で文章を作成", size: 45
+          = f.submit '作成'
 
 css:
   .post-show-top {
@@ -447,7 +440,7 @@ css:
 
   .free-post-contents {
     margin-top: 2%;
-    margin-bottom: 4%;
+    margin-bottom: 6%;
   }
 
   .free-post-content {
@@ -475,6 +468,12 @@ css:
     color: #999;
   }
 
+  .free-post-contents .not-free-post {
+    padding: 3% 7%;
+    color: #777;
+    font-size: 0.91rem;
+  }
+
   .post-show-free-post-form {
     margin-top: 8%;
   }
@@ -487,6 +486,10 @@ css:
     font-size: 1.1rem;
     font-weight: normal;
     color: #777;
+  }
+
+  .free-form {
+    width: 360px;
   }
 
   .post-show-free-post-form .free-form input[type="text"] {

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -91,7 +91,7 @@
       = link_to user_path(@post.user) do
         ul
           - if @post.user.img.present?
-            li.image = image_tag @post.user.img.url 
+            li.image = image_tag @post.user.img.url
           - else
             li.image = image_tag "no_image.png"
           li.name #{@post.user.name}
@@ -116,14 +116,11 @@
                   p.time = "#{time_ago_in_words(fc.created_at)}前"
           - else
             p.not-free-post このスペースは誰でも自由に書き込むことが出来ます
-
-
     // フリーコメントの作成フォーム
     .post-show-free-post-form
       .free-post-form-title
         h3 フリーコメントを作成
       .free-form
-        form
         = form_for [@post, @free_comment] do |f|
           - unless user_signed_in?
             = f.text_field :username, value: @default_name, placeholder: "25文字以内でHNを設定（空白禁止）", size: 32
@@ -472,7 +469,7 @@ css:
     color: #999;
   }
 
-  .free-post-contents .not-free-post {
+  .free-posts-wrapper .not-free-post {
     padding: 3% 7%;
     color: #777;
     font-size: 0.91rem;

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -458,6 +458,10 @@ css:
     color: #444;
   }
 
+  .free-post-msg {
+    margin-right: 6%;
+  }
+
   .free-post-msg .post-content {
     font-size: 0.88rem;
     color: #333;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     post :confirm, action: :confirm_new, on: :new
     post 'add', to: 'likes#create'
     delete '/add', to: 'likes#destroy'
+    resources :free_comments, only: [:create]
   end
 
   resources :users, only: [:index, :show]
@@ -14,7 +15,6 @@ Rails.application.routes.draw do
   resources :messages, only: [:create]
   resources :rooms, only: [:create, :show, :index]
   resources :articles
-  resources :comments, only: [:create]
 
   # 静的ページ
   get '/lp', to: 'static#lp'


### PR DESCRIPTION
## Pivotal
- https://www.pivotaltracker.com/story/show/177519935

## 詳細

「#46 未ログインユーザが作品にコメントできる機能」 と「 #45 未ログインユーザが作品にコメントできる欄2」で対応したそれぞれの要素をつなぎ合わせた。

## 注目して欲しい箇所

- コントローラー名を変更した
以前は`comments_controller`だったが、この実装で、`free_comments_controller`に名称を変更した。

<br>

## 補足
レスポンシブ対応も思ったより工数がかからずに実装できたので、このPull Requestで対応した。
以下のURLが対象のPivotal。

<br>

**フリーコメント欄のレスポンシブ対応**
- https://www.pivotaltracker.com/story/show/177519813
