### PR TITLE
[#176587788]micropostへの星機能

### DIFF
--- a/app/assets/javascripts/micropost_stars.coffee
+++ b/app/assets/javascripts/micropost_stars.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/micropost_stars.scss
+++ b/app/assets/stylesheets/micropost_stars.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the MicropostStars controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/micropost_stars_controller.rb
+++ b/app/controllers/micropost_stars_controller.rb
@@ -1,0 +1,17 @@
+class MicropostStarsController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def create
+    @post = Post.find(params[:post_id])
+    micropost = Micropost.first # TODO: 後で指定したMicropostの取得に変更する
+    user = current_user || nil
+    micropost_star = MicropostStar.new(micropost: micropost, user: user)
+
+    ActiveRecord::Base.transaction do
+      micropost_star.save!
+      micropost.update!(star_count: micropost.micropost_star.count)
+    end
+
+    redirect_to @post
+  end
+end

--- a/app/controllers/micropost_stars_controller.rb
+++ b/app/controllers/micropost_stars_controller.rb
@@ -2,16 +2,16 @@ class MicropostStarsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def create
-    @post = Post.find(params[:post_id])
-    micropost = Micropost.first # TODO: 後で指定したMicropostの取得に変更する
+    post = Post.find(params[:post_id])
+    micropost = Micropost.find(params[:micropost_id])
     user = current_user || nil
     micropost_star = MicropostStar.new(micropost: micropost, user: user)
 
     ActiveRecord::Base.transaction do
       micropost_star.save!
-      micropost.update!(star_count: micropost.micropost_star.count)
+      micropost.update!(star_count: micropost.micropost_stars.count)
     end
 
-    redirect_to @post
+    redirect_to post
   end
 end

--- a/app/helpers/micropost_stars_helper.rb
+++ b/app/helpers/micropost_stars_helper.rb
@@ -1,0 +1,2 @@
+module MicropostStarsHelper
+end

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module MicropostsHelper
+
+  def micropost_star_count(micropost)
+    count = micropost.star_count
+
+    count > 9999 ? '9999+' : count
+  end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Micropost < ApplicationRecord
-  validates :content, presence: true, length: { maximum: 55 }
+  has_many :micropost_stars
   belongs_to :user
   belongs_to :post
+  
+  validates :content, presence: true, length: { maximum: 55 }
 end

--- a/app/models/micropost_star.rb
+++ b/app/models/micropost_star.rb
@@ -1,2 +1,6 @@
+# frozen_string_literal: true
+
 class MicropostStar < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :micropost
 end

--- a/app/models/micropost_star.rb
+++ b/app/models/micropost_star.rb
@@ -1,0 +1,2 @@
+class MicropostStar < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
   has_many :articles
+  has_many :micropost_stars
 
   validates :name, presence: true, length: { maximum: 25 }
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -65,7 +65,7 @@
             - if user_signed_in? && micropost.user_id == current_user.id
               p = link_to "・削除", [@post, micropost], method: :delete, data: { confirm: '削除?' }
           .post-log-star
-            p star
+            p = "#{micropost.star_count}star"
             p = link_to'押せる', post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post
       .post-add
         // 1行作業

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -60,14 +60,14 @@
             .post-log-content
               p.name = link_to "#{micropost.user.name}", "/users/#{micropost.user_id}"
               p.micro = micropost.content
+            .post-log-star
+              p = link_to post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post do
+                i.far.fa-star.fa-lg.star-color
+              p.star-p = micropost_star_count(micropost)
           .post-log-info
             p = "#{time_ago_in_words(micropost.created_at)}前"
             - if user_signed_in? && micropost.user_id == current_user.id
               p = link_to "・削除", [@post, micropost], method: :delete, data: { confirm: '削除?' }
-          .post-log-star
-            p = link_to post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post do
-              i.far.fa-star.fa-lg.star-color
-            p.star-p = micropost_star_count(micropost)
       .post-add
         // 1行作業
         .micropost-form
@@ -137,7 +137,9 @@ css:
   }
 
   .star-p {
+    font-size: 0.88rem;
     color: #ffcc33;
+    text-align: center;
   }
 
   .post-show-top {
@@ -300,6 +302,10 @@ css:
   .post-log-content p a:hover {
     color: #0a9dd1;
     transition: .3s;
+  }
+
+  .post-log-star {
+    margin-left: 5%;
   }
 
   .post-log .post-log-info {

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -64,6 +64,9 @@
             p = "#{time_ago_in_words(micropost.created_at)}前"
             - if user_signed_in? && micropost.user_id == current_user.id
               p = link_to "・削除", [@post, micropost], method: :delete, data: { confirm: '削除?' }
+          .post-log-star
+            p star
+            p = link_to'押せる', post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post
       .post-add
         // 1行作業
         .micropost-form

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -65,8 +65,9 @@
             - if user_signed_in? && micropost.user_id == current_user.id
               p = link_to "・削除", [@post, micropost], method: :delete, data: { confirm: '削除?' }
           .post-log-star
-            p = link_to'押せるstar', post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post
-            p = micropost_star_count(micropost)
+            p = link_to post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post do
+              i.far.fa-star.fa-lg.star-color
+            p.star-p = micropost_star_count(micropost)
       .post-add
         // 1行作業
         .micropost-form
@@ -131,6 +132,14 @@
           = f.submit '作成'
 
 css:
+  .star-color {
+    color: #ffcc33;
+  }
+
+  .star-p {
+    color: #ffcc33;
+  }
+
   .post-show-top {
     background-color: rgb(244, 244, 244);
     padding-top: 1.3%;

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -65,8 +65,8 @@
             - if user_signed_in? && micropost.user_id == current_user.id
               p = link_to "・削除", [@post, micropost], method: :delete, data: { confirm: '削除?' }
           .post-log-star
-            p = "#{micropost.star_count}star"
-            p = link_to'押せる', post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post
+            p = link_to'押せるstar', post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post
+            p = micropost_star_count(micropost)
       .post-add
         // 1行作業
         .micropost-form

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -306,6 +306,7 @@ css:
 
   .post-log-star {
     margin-left: 5%;
+    margin-top: 2%;
   }
 
   .post-log .post-log-info {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,10 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :posts do
-    resources :microposts, only: [:create, :destroy]
+    resources :microposts, only: [:create, :destroy] do
+      resources :micropost_stars, only: :create
+    end
+
     post :confirm, action: :confirm_new, on: :new
     post 'add', to: 'likes#create'
     delete '/add', to: 'likes#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,11 @@ Rails.application.routes.draw do
       resources :micropost_stars, only: :create
     end
 
+    resources :free_comments, only: [:create] 
+
     post :confirm, action: :confirm_new, on: :new
     post 'add', to: 'likes#create'
     delete '/add', to: 'likes#destroy'
-    resources :free_comments, only: [:create]
   end
 
   resources :users, only: [:index, :show]

--- a/db/migrate/20210331014725_create_micropost_stars.rb
+++ b/db/migrate/20210331014725_create_micropost_stars.rb
@@ -1,0 +1,10 @@
+class CreateMicropostStars < ActiveRecord::Migration[6.1]
+  def change
+    create_table :micropost_stars do |t|
+      t.references :user, index: true
+      t.references :micropost, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210331020518_add_column_microposts_to_star_count.rb
+++ b/db/migrate/20210331020518_add_column_microposts_to_star_count.rb
@@ -1,0 +1,5 @@
+class AddColumnMicropostsToStarCount < ActiveRecord::Migration[6.1]
+  def change
+    add_column :microposts, :star_count, :integer, limit: 5, null: false
+  end
+end

--- a/db/migrate/20210331025031_add_default_star_count_to_microposts.rb
+++ b/db/migrate/20210331025031_add_default_star_count_to_microposts.rb
@@ -1,0 +1,5 @@
+class AddDefaultStarCountToMicroposts < ActiveRecord::Migration[6.1]
+  def change
+    change_column :microposts, :star_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_143255) do
+ActiveRecord::Schema.define(version: 2021_03_31_014725) do
 
   create_table "active_admin_comments", charset: "utf8", force: :cascade do |t|
     t.string "namespace"
@@ -92,6 +92,15 @@ ActiveRecord::Schema.define(version: 2021_03_25_143255) do
     t.datetime "updated_at", null: false
     t.index ["room_id"], name: "index_messages_on_room_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "micropost_stars", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "micropost_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["micropost_id"], name: "index_micropost_stars_on_micropost_id"
+    t.index ["user_id"], name: "index_micropost_stars_on_user_id"
   end
 
   create_table "microposts", charset: "utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_014725) do
+ActiveRecord::Schema.define(version: 2021_03_31_020518) do
 
   create_table "active_admin_comments", charset: "utf8", force: :cascade do |t|
     t.string "namespace"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_014725) do
     t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "star_count", null: false
     t.index ["post_id"], name: "index_microposts_on_post_id"
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_020518) do
+ActiveRecord::Schema.define(version: 2021_03_31_025031) do
 
   create_table "active_admin_comments", charset: "utf8", force: :cascade do |t|
     t.string "namespace"
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_020518) do
     t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "star_count", null: false
+    t.integer "star_count", default: 0, null: false
     t.index ["post_id"], name: "index_microposts_on_post_id"
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end

--- a/spec/models/micropost_star_spec.rb
+++ b/spec/models/micropost_star_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MicropostStar, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/micropost_stars_spec.rb
+++ b/spec/requests/micropost_stars_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "MicropostStars", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## Pivotal
- https://www.pivotaltracker.com/story/show/176587788

## 作業詳細

### Front
- micropostsの横に星の表示

### Back
- Micropostsテーブルに星カラムを追加
- 星を押したときのcreateメソッド
- 星に対するバリデーション


- micropost_stars#createでやること
  - 対象のMicropostの取得
  - 対象のユーザが存在するか
  - 存在するのであればuser_idにはcurrent_user idを入れる
  - 存在しなければuser_idはnilを入れる
  - MicropostStarのレコード作成
  - @micropost.micropost_stars.countを@micropost.srat_countに反映

### micropostにstar_countカラムをわざわざ作った理由
- 「9999+」を簡単に表現するため
- 桁数のバリデーションが楽だから
- 今後の人気ランキングの修正が楽になるから


