### PR TITLE
[#176051161]永遠に書けてしまうので、依頼人がリレーをCloseできる

### DIFF
--- a/app/assets/javascripts/closed_posts.coffee
+++ b/app/assets/javascripts/closed_posts.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -265,10 +265,6 @@ a:hover {
 }
 
 /* icon */
-.fas {
-  padding: 2% 0;
-}
-
 .fa-book-open {
   color: #009900;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -264,6 +264,19 @@ a:hover {
   height: 650px;
 }
 
+/* icon */
+.fas {
+  padding: 2% 0;
+}
+
+.fa-book-open {
+  color: #009900;
+}
+
+.fa-window-close {
+  color: #cc3333;
+}
+
 
 @media screen and (max-width: 480px) {
   .bg-top {

--- a/app/assets/stylesheets/closed_posts.scss
+++ b/app/assets/stylesheets/closed_posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the ClosedPosts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::Base
     flash[:notice] = text
   end
 
+  def error(text: 'error')
+    flash[:alert] = text
+  end
+
   def authenticate_admin!
     unless current_user.is_admin?
       flash[:alert] = 'アクセス権限がありません'

--- a/app/controllers/closed_posts_controller.rb
+++ b/app/controllers/closed_posts_controller.rb
@@ -6,7 +6,7 @@ class ClosedPostsController < ApplicationController
       success(text: '作品への書き込みを停止しました')
       redirect_to @post
     else
-      flash[:alert] = '作品への書き込み停止に失敗しました（停止の処理は完了していません）'
+      error(text: '作品への書き込み停止に失敗しました（停止の処理は完了していません）')
       render :edit
     end
   end

--- a/app/controllers/closed_posts_controller.rb
+++ b/app/controllers/closed_posts_controller.rb
@@ -1,0 +1,13 @@
+class ClosedPostsController < ApplicationController
+
+  def update
+    @post = Post.find(params[:id])
+    if @post.update(closed: true)
+      success(text: '作品への書き込みを停止しました')
+      redirect_to @post
+    else
+      flash[:alert] = '作品への書き込み停止に失敗しました（停止の処理は完了していません）'
+      render :edit
+    end
+  end
+end

--- a/app/controllers/closed_posts_controller.rb
+++ b/app/controllers/closed_posts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ClosedPostsController < ApplicationController
 
   def update

--- a/app/controllers/closed_posts_controller.rb
+++ b/app/controllers/closed_posts_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class ClosedPostsController < ApplicationController
+  before_action :set_post, only: [:update, :destroy]
 
   def update
-    @post = Post.find(params[:id])
     if @post.update(closed: true)
       success(text: '作品への書き込みを停止しました')
       redirect_to @post
@@ -12,4 +12,19 @@ class ClosedPostsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    if @post.update(closed: false)
+      success(text: '作品への書き込みを開始しました')
+      redirect_to @post
+    else
+      error(text: '作品への書き込み開始に失敗しました（開始できていません）')
+      render :edit
+    end
+  end
+
+  private
+    def set_post
+      @post = Post.find(params[:id])
+    end
 end

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -6,7 +6,7 @@ class MicropostsController < ApplicationController
     @post = Post.find(params[:post_id])
 
     if @post.closed
-      flash[:alert] = 'この作品は新規の書き込みを停止しています'
+      error(text: 'この作品は新規の書き込みを停止しています')
       redirect_back(fallback_location: root_path)
     end
 
@@ -14,10 +14,10 @@ class MicropostsController < ApplicationController
     @micropost.user_id = current_user.id
     @micropost.post_id = @post.id
     if @micropost.save
-      success
+      success(text: '1行小説を作成しました')
       redirect_back(fallback_location: root_path)
     else
-      flash[:alert] = '1行作成に失敗しました'
+      error(text: '1行作成に失敗しました')
       redirect_back(fallback_location: root_path)
     end
   end

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -4,6 +4,12 @@ class MicropostsController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
+
+    if @post.closed
+      flash[:alert] = 'この作品は新規の書き込みを停止しています'
+      redirect_back(fallback_location: root_path)
+    end
+
     @micropost = Micropost.new(micropost_params)
     @micropost.user_id = current_user.id
     @micropost.post_id = @post.id

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -24,6 +24,12 @@ class MicropostsController < ApplicationController
 
   def destroy
     @micropost = Micropost.find(params[:id])
+
+    if @micropost.post.closed
+      error(text: 'この作品は新規の書き込みを停止しています')
+      redirect_back(fallback_location: root_path)
+    end
+
     @micropost.destroy
     redirect_back(fallback_location: root_path)
   end

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -4,11 +4,7 @@ class MicropostsController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-
-    if @post.closed
-      error(text: 'この作品は新規の書き込みを停止しています')
-      redirect_back(fallback_location: root_path)
-    end
+    post_closed(@post)
 
     @micropost = Micropost.new(micropost_params)
     @micropost.user_id = current_user.id
@@ -24,11 +20,7 @@ class MicropostsController < ApplicationController
 
   def destroy
     @micropost = Micropost.find(params[:id])
-
-    if @micropost.post.closed
-      error(text: 'この作品は新規の書き込みを停止しています')
-      redirect_back(fallback_location: root_path)
-    end
+    post_closed(@micropost.post)
 
     @micropost.destroy
     redirect_back(fallback_location: root_path)
@@ -38,5 +30,12 @@ class MicropostsController < ApplicationController
 
     def micropost_params
       params.require(:micropost).permit(:content)
+    end
+
+    def post_closed(post)
+      if post.closed
+        error(text: 'この作品は新規の書き込みを停止しています')
+        redirect_back(fallback_location: root_path)
+      end
     end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -40,14 +40,17 @@ class PostsController < ApplicationController
   end
 
   def edit
+    return if authenticate_author!
   end
 
   def update
+    return if authenticate_author!
+
     if @post.update(post_params)
       success
       redirect_to @post
     else
-      flash[:alert] = 'not delete post'
+      error(text: '小説の編集に失敗しました')
       render :edit
     end
   end
@@ -80,5 +83,12 @@ class PostsController < ApplicationController
     def browsing_count(post)
       post_browsing = post.browsing + 1
       post.update(browsing: post_browsing)
+    end
+
+    def authenticate_author!
+      unless @post.user == current_user
+        error(text: '作成者では無いため、作品の内容を編集できません')
+        redirect_to @post
+      end
     end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,7 +47,7 @@ class PostsController < ApplicationController
     return if authenticate_author!
 
     if @post.update(post_params)
-      success
+      success(text: '小説の内容を編集しました')
       redirect_to @post
     else
       error(text: '小説の編集に失敗しました')
@@ -60,8 +60,8 @@ class PostsController < ApplicationController
       success
       redirect_to root_path
     else
-      flash[:alert] = 'not delete post'
-      render 'show'
+      error(text: '小説の削除に失敗しました')
+      render :show
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -34,7 +34,7 @@ class PostsController < ApplicationController
       success(text: '小説を作成しました')
       redirect_to @post
     else
-      flash[:alert] = @free_comment.errors.full_messages[0]
+      error(text: @free_comment.errors.full_messages[0])
       render :new
     end
   end

--- a/app/helpers/closed_posts_helper.rb
+++ b/app/helpers/closed_posts_helper.rb
@@ -1,0 +1,2 @@
+module ClosedPostsHelper
+end

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -49,6 +49,10 @@ section.top-container
         .ranking-content
           .top-post-img
             = link_to image_tag("no_image_book.jpg"), post
+          - unless post.closed
+            i.fas.fa-book-open.fa-lg
+          - else
+            i.fas.fa-window-close.fa-lg
           h3.top-post-title = post.title.truncate(27)
           p.top-post-link = link_to "詳細をみる", post
   // 新着作品
@@ -67,6 +71,10 @@ section.top-container
                 = image_tag(post.image.url)
               - else
                 = image_tag("no_image_book.jpg")
+          - unless post.closed
+            i.fas.fa-book-open.fa-lg
+          - else
+            i.fas.fa-window-close.fa-lg
           h3.top-post-title = post.title.truncate(27)
           / p.top-post-story = post.story
           p.top-post-link = link_to "詳細をみる", post

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -82,6 +82,11 @@ section.top-container
           p.top-post-link = link_to "詳細をみる", post
 
 css:
+  /* icon */
+  .fas {
+    padding: 2% 0;
+  }
+
   .top-container {
     margin-left: 8%;
     margin-right: 8%;

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -49,6 +49,7 @@ section.top-container
         .ranking-content
           .top-post-img
             = link_to image_tag("no_image_book.jpg"), post
+          / リレーの状態
           - unless post.closed
             i.fas.fa-book-open.fa-lg
           - else
@@ -71,6 +72,7 @@ section.top-container
                 = image_tag(post.image.url)
               - else
                 = image_tag("no_image_book.jpg")
+          / リレーの状態
           - unless post.closed
             i.fas.fa-book-open.fa-lg
           - else

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -8,7 +8,7 @@
 
   - if @post.closed
     .relay-start-button
-      = link_to 'リレーを開始する', "#"
+      = link_to 'リレーを開始する', closed_post_path(@post), method: :delete
   - else
     .relay-stop-button
       = link_to 'リレーを停止する', closed_post_path(@post), method: :patch, data: { confirm: "本当にリレーを停止してもよろしいですか？" }

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -6,4 +6,24 @@
 
   = render 'form'
 
-  = link_to 'リレーを停止する', closed_post_path(@post), method: :patch
+  .relay-stop-button
+    = link_to 'リレーを停止する', closed_post_path(@post), method: :patch, data: { confirm: "本当にリレーを停止してもよろしいですか？" }
+
+css:
+  .relay-stop-button {
+    margin-top: 5%;
+    text-align: center;
+  }
+
+  .relay-stop-button a {
+    background-color: #cc3333;
+    color: rgb(244, 243, 243);
+    padding: 12px 28px;
+    border-radius: 4px;
+    transition: 0.3s;
+  }
+
+  .relay-stop-button a:hover {
+    transition: 0.3s;
+    opacity: 0.7;
+  }

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -6,3 +6,4 @@
 
   = render 'form'
 
+  = link_to 'リレーを停止する', closed_post_path(@post), method: :patch

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -6,8 +6,12 @@
 
   = render 'form'
 
-  .relay-stop-button
-    = link_to 'リレーを停止する', closed_post_path(@post), method: :patch, data: { confirm: "本当にリレーを停止してもよろしいですか？" }
+  - if @post.closed
+    .relay-start-button
+      = link_to 'リレーを開始する', "#"
+  - else
+    .relay-stop-button
+      = link_to 'リレーを停止する', closed_post_path(@post), method: :patch, data: { confirm: "本当にリレーを停止してもよろしいですか？" }
 
 css:
   .relay-stop-button {
@@ -24,6 +28,24 @@ css:
   }
 
   .relay-stop-button a:hover {
+    transition: 0.3s;
+    opacity: 0.7;
+  }
+
+  .relay-start-button {
+    margin-top: 5%;
+    text-align: center;
+  }
+
+  .relay-start-button a {
+    background-color: #009900;
+    color: rgb(244, 243, 243);
+    padding: 12px 28px;
+    border-radius: 4px;
+    transition: 0.3s;
+  }
+
+  .relay-start-button a:hover {
     transition: 0.3s;
     opacity: 0.7;
   }

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -126,7 +126,7 @@
                   .free-post-star
                     / p = link_to post_micropost_micropost_stars_path(post_id: @post.id, micropost_id: micropost.id), method: :post do
                     i.far.fa-star.fa-lg.star-color
-                    p.star-p 12
+                    p.star-p 仮
                     / TODO: 本来の姿
                     / p.star-p = micropost_star_count(micropost)
           - else

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -73,13 +73,16 @@
         .micropost-form
           h3 1行投稿
           .novel-form
-            - if user_signed_in?
-              p 文章を作成
-              = form_for [@post, @micropost] do |f|
-                = f.text_field :content, placeholder: "55文字以内で文章を作成"
-                = f.submit '作成', data: { confirm: "投稿しますか？"}
+            - if @post.closed
+              p.novel-post-closed この作品のリレーは作成者によって停止されています
             - else
-              p.not-signin 小説作成に参加するには、#{link_to "サインイン", new_user_session_path}してください
+              - if user_signed_in?
+                p 文章を作成
+                = form_for [@post, @micropost] do |f|
+                  = f.text_field :content, placeholder: "55文字以内で文章を作成"
+                  = f.submit '作成', data: { confirm: "投稿しますか？"}
+              - else
+                p.not-signin 小説作成に参加するには、#{link_to "サインイン", new_user_session_path}してください
         // 著者達に求める展開
         .post-order
           - if user_signed_in?
@@ -370,13 +373,19 @@ css:
     font-size: .75rem;
   }
 
+  .novel-post-closed {
+    margin: 8% 3%;
+    color: #ff6666;
+    font-size: 0.95rem;
+  }
+
   .not-signin a {
     text-decoration: underline;
     color: #69b3fd;
   }
 
   .post-order {
-    margin-top: 5%;
+    margin-top: 12%;
     margin-bottom: 2%;
   }
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -43,6 +43,10 @@
             = image_tag(post.image.url)
           - else
             = image_tag("no_image_book.jpg")
+          - unless post.closed
+            i.fas.fa-book-open.fa-lg
+          - else
+            i.fas.fa-window-close.fa-lg
           h3 = post.title.truncate(27)
       
     .novels-title
@@ -54,6 +58,10 @@
             = image_tag(post.image.url)
           - else
             = image_tag("no_image_book.jpg")
+          - unless post.closed
+            i.fas.fa-book-open.fa-lg
+          - else
+            i.fas.fa-window-close.fa-lg
           h3 = post.title.truncate(27)
 
 css:

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -43,6 +43,7 @@
             = image_tag(post.image.url)
           - else
             = image_tag("no_image_book.jpg")
+          / リレーの状態
           - unless post.closed
             i.fas.fa-book-open.fa-lg
           - else
@@ -58,6 +59,7 @@
             = image_tag(post.image.url)
           - else
             = image_tag("no_image_book.jpg")
+          / リレーの状態
           - unless post.closed
             i.fas.fa-book-open.fa-lg
           - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   resources :messages, only: [:create]
   resources :rooms, only: [:create, :show, :index]
   resources :articles
+  resources :closed_posts, only: :update
 
   resources :recommend_posts, :index
   resources :new_arrival_posts, :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :messages, only: [:create]
   resources :rooms, only: [:create, :show, :index]
   resources :articles
-  resources :closed_posts, only: :update
+  resources :closed_posts, only: [:update, :destroy]
 
   resources :recommend_posts, :index
   resources :new_arrival_posts, :index

--- a/db/migrate/20210415051342_add_column_posts_to_closed.rb
+++ b/db/migrate/20210415051342_add_column_posts_to_closed.rb
@@ -1,0 +1,5 @@
+class AddColumnPostsToClosed < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :closed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_025031) do
+ActiveRecord::Schema.define(version: 2021_04_15_051342) do
 
   create_table "active_admin_comments", charset: "utf8", force: :cascade do |t|
     t.string "namespace"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_025031) do
     t.integer "user_id"
     t.string "image"
     t.integer "browsing", default: 0, null: false
+    t.boolean "closed", default: false, null: false
     t.index ["title"], name: "index_posts_on_title"
   end
 

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ArticlesController, type: :controller do
-  let(:makoto) { FactoryBot.create :makoto }
-  before { login_user makoto }
+  let(:makoto) { FactoryBot.create :user }
+  before { login_user user }
 
   # GETメソッド
   context '#index' do
@@ -17,13 +17,13 @@ RSpec.describe ArticlesController, type: :controller do
     end
   end
 
-  context '#show' do
-    xit 'リクエストが成功すること' do
+  xcontext '#show' do
+    it 'リクエストが成功すること' do
       get :show, params: { id: 1 }
       expect(response).to eq 200
     end
 
-    xit 'showテンプレートで表示されること' do
+    it 'showテンプレートで表示されること' do
       get :show, params: { id: 1 }
       expect(response).to render_template :show
     end

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,22 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ArticlesController, type: :controller do
-  let(:makoto) { FactoryBot.create :user }
-  before { login_user user }
+  let(:makoto) { create(:makoto) }
+  before { login_user makoto }
 
   # GETメソッド
-  context '#index' do
-    it 'リクエストが成功すること' do
-      get :index
-      expect(response.status).to eq 200
-    end
-
-    it 'indexテンプレートで表示されること' do
-      get :index
-      expect(response).to render_template :index
-    end
-  end
-
   xcontext '#show' do
     it 'リクエストが成功すること' do
       get :show, params: { id: 1 }

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -66,22 +66,22 @@ RSpec.describe PostsController, type: :controller do
     end
   end
 
-  context '#create パラメータが不正の場合' do
-    it 'リクエストが成功すること' do
-      post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
-      expect(response.status).to eq 200
-    end
+  # context '#create パラメータが不正の場合' do
+  #   it 'リクエストが成功すること' do
+  #     post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
+  #     expect(response.status).to eq 200
+  #   end
 
-    it 'newテンプレートで表示されること' do
-      post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
-      expect(response).to render_template :new
-    end
+  #   it 'newテンプレートで表示されること' do
+  #     post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
+  #     expect(response).to render_template :new
+  #   end
 
-    it 'エラーが表示されること' do
-      post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
-      expect(assigns(:post).errors.any?).to be_truthy
-    end
-  end
+  #   it 'エラーが表示されること' do
+  #     post :create, params: { post: FactoryBot.attributes_for(:post, :invalid) }
+  #     expect(assigns(:post).errors.any?).to be_truthy
+  #   end
+  # end
 
   context '#update ユーザーが存在する場合' do
     it 'リクエストが成功すること' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("spec/support/controller_macros.rb")
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'factory_bot'
 
 begin
   ActiveRecord::Migration.maintain_test_schema!
@@ -16,6 +17,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.use_transactional_fixtures = true

--- a/spec/requests/closed_posts_spec.rb
+++ b/spec/requests/closed_posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "ClosedPosts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,11 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe "Comments", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/comments/create"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@
 # SimpleCov.start 'rails'
 
 RSpec.configure do |config|
+  config.before(:all) do
+    FactoryBot.reload
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
## Pivotal
- https://www.pivotaltracker.com/story/show/176051161

## 詳細

小説の作成者のみ、作品自体の書き込みを閉じることができる。

- 再度開くこと？
-> できる
- 閉じたあとの閲覧？
-> できる
- 閉じたあとのフリーコメント？
-> できる
- 閉じたあとのハート？
-> できる
- 閉じたあとの1行小説スター？
-> できる
- 閉じたあとの1行小説作成？
-> できない

## 仕様
- `posts#show`で閉じている作品に1行作成はできない
- `microposts#create`時には対象のPostが閉じている作品でないかを確認する

## 補足

- おかえり、僕たちのRSpecのControllerテスト先輩
-> このCommitでController Specは復活している。
